### PR TITLE
[dash] update proto_utils to allow pa_validation = false

### DIFF
--- a/tests/dash/proto_utils.py
+++ b/tests/dash/proto_utils.py
@@ -81,7 +81,8 @@ def route_rule_from_json(json_obj):
     pb.action_type = RoutingType.ROUTING_TYPE_VNET_ENCAP
     pb.priority = int(json_obj["priority"])
     pb.pa_validation = json_obj["pa_validation"] == "true"
-    pb.vnet = json_obj["vnet"]
+    if json_obj["pa_validation"] == "true":
+        pb.vnet = json_obj["vnet"]
     return pb
 
 


### PR DESCRIPTION
Add a logic to set RouteRule().vnet only if pa_validation is set to true.
This is to allow a configuration with pa_validation=false which requires vnet field to not be set.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
